### PR TITLE
Fixes wrong testcase

### DIFF
--- a/backend/tests/Controller/MesssageControllerTest.php
+++ b/backend/tests/Controller/MesssageControllerTest.php
@@ -33,7 +33,8 @@ class MessageControllerTest extends \PHPUnit_Framework_TestCase
 
             $request->getBody()->write(json_encode($message));
             $response = new \Zend\Diactoros\Response();
-            $response = $this->app->run($request, $response);
+            $app = new \GianArb\Penny\App();
+            $response = $app->run($request, $response);
             if ($ii == 11) {
                 $assertStatusCode = 429;
             }


### PR DESCRIPTION
Penny framework attaches the dispatchable action during the
`run` method. For that reason if you don't recreate the Application
itself you attach the same action for every loop cycle.

```
Cycle 1 -> attach 1
Cycle 2 -> attach 1 -> attach 1
Cycle 3 -> attach 1 -> attach 1 -> attach 1
```

So the redis listener at time 1 is engaged once, at time 2 is engaged
twice (plus the previus engagement) at time three ... So at time 5 the
limit count is 15 and not 5...

This should be considered as a Penny bug...